### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
         }
     ],
     "require": {
-        "php": "~7.0.0|~7.1.0",
         "paypal/rest-api-sdk-php" : "^1.13.0"
     },
     "require-dev": {


### PR DESCRIPTION
Removal of the php version restriction in the composer.json, following Magento best practices, only the core project should restrict the php version.